### PR TITLE
Expose more finegrained control over cluster nodes

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -401,8 +401,14 @@ func (c *Cluster) GetForAddr(addr string) (redis.Conn, error) {
 //
 // NOTE: This is a cached view of the cluster. Refresh can be called to
 //       get an actual state of the cluster.
-func (c *Cluster) Addrs() []string {
-	return c.getNodeAddrs(false)
+func (c *Cluster) Addrs(withReplicas ...bool) []string {
+	var preferReplicas bool
+
+	if len(withReplicas) > 0 {
+		preferReplicas = withReplicas[0]
+	}
+
+	return c.getNodeAddrs(preferReplicas)
 }
 
 // Close releases the resources used by the cluster. It closes all the


### PR DESCRIPTION
Currently we have a use-case where we need to use SCAN and HSCAN over all nodes in the cluster and filter what is necessary. The current implementation of redisc doesn't expose finegrained control over the discovered/refreshed nodes in the cluster and get a node specific connection. 