### PR TITLE
Add PoolWaitTime to Cluster.

### DIFF
--- a/cluster_go16.go
+++ b/cluster_go16.go
@@ -1,0 +1,15 @@
+// +build !go1.7
+
+package redisc
+
+import (
+	"github.com/gomodule/redigo/redis"
+)
+
+// get connection from the pool
+// pre go1.7, Pool has no GetContext method, so it always
+// calls Get.
+func (c *Cluster) getFromPool(p *redis.Pool) (redis.Conn, error) {
+	conn := p.Get()
+	return conn, conn.Err()
+}

--- a/cluster_go16_test.go
+++ b/cluster_go16_test.go
@@ -1,0 +1,37 @@
+// +build !go1.7
+
+package redisc
+
+import (
+	"testing"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/mna/redisc/redistest"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetPool
+func TestGetPool(t *testing.T) {
+	s := redistest.StartMockServer(t, func(cmd string, args ...string) interface{} {
+		return nil
+	})
+	defer s.Close()
+
+	p := &redis.Pool{
+		MaxActive: 1,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", s.Addr)
+		},
+	}
+	c := Cluster{}
+
+	// fist connection is OK
+	conn, err := c.getFromPool(p)
+	assert.NoError(t, err)
+
+	// second connection should be failed because we only have 1 MaxActive
+	_, err = c.getFromPool(p)
+	assert.Error(t, err)
+
+	conn.Close()
+}

--- a/cluster_go17.go
+++ b/cluster_go17.go
@@ -1,0 +1,23 @@
+// +build go1.7
+
+package redisc
+
+import (
+	"context"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// get connection from the pool.
+// use GetContext if PoolWaitTime > 0
+func (c *Cluster) getFromPool(p *redis.Pool) (redis.Conn, error) {
+	if c.PoolWaitTime <= 0 {
+		conn := p.Get()
+		return conn, conn.Err()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.PoolWaitTime)
+	defer cancel()
+
+	return p.GetContext(ctx)
+}

--- a/cluster_go17_test.go
+++ b/cluster_go17_test.go
@@ -1,0 +1,82 @@
+// +build go1.7
+
+package redisc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/mna/redisc/redistest"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetPoolTimedOut test case where we can't get the connection because the pool
+// is full
+func TestGetPoolTimedOut(t *testing.T) {
+	s := redistest.StartMockServer(t, func(cmd string, args ...string) interface{} {
+		return nil
+	})
+	defer s.Close()
+
+	p := &redis.Pool{
+		MaxActive: 1,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", s.Addr)
+		},
+		Wait: true,
+	}
+	c := Cluster{
+		PoolWaitTime: 100 * time.Millisecond,
+	}
+	conn, err := c.getFromPool(p)
+	assert.NoError(t, err)
+
+	// second connection should be failed because we only have 1 MaxActive
+	_, err = c.getFromPool(p)
+	assert.Error(t, err)
+
+	conn.Close()
+}
+
+// TestGetPoolGotOnFull test that we could get the connection when the pool
+// is full and we can wait for it
+func TestGetPoolGotOnFull(t *testing.T) {
+	s := redistest.StartMockServer(t, func(cmd string, args ...string) interface{} {
+		return nil
+	})
+	defer s.Close()
+
+	var (
+		usageTime = 100 * time.Millisecond // how long the connection will be used
+		waitTime  = 3 * usageTime          // how long we want to wait
+	)
+
+	p := &redis.Pool{
+		MaxActive: 1,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", s.Addr)
+		},
+		Wait: true,
+	}
+	c := Cluster{
+		PoolWaitTime: waitTime,
+	}
+
+	// first connection OK
+	conn, err := c.getFromPool(p)
+	assert.NoError(t, err)
+
+	// second connection should be failed because we only have 1 MaxActive
+	_, err = c.getFromPool(p)
+	assert.Error(t, err)
+
+	go func() {
+		time.Sleep(usageTime) // sleep before close, to simulate waiting for connection
+		conn.Close()
+	}()
+	conn2, err := c.getFromPool(p)
+	assert.NoError(t, err)
+
+	conn2.Close()
+}


### PR DESCRIPTION
If > 0, it will wait for the given time when getting connection from the
pool and the pool is full.

It is implemented using [GetContext](https://godoc.org/github.com/gomodule/redigo/redis#Pool.GetContext), so will only work on Go > 1.7

Fixes #22