### PR TITLE
Improve the reliability of the refresh process due to the loss of slots

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -106,11 +106,14 @@ func (c *Cluster) refresh(bg bool) error {
 	var errMsgs []string
 	var oldm, newm [HashSlots][]string
 
-	// get all node addrs, including replicas
-	addrs, _ := c.getNodeAddrs(true)
-	// when addrs cannot be obtained, StartupNodes is always used to populate
+	// get master nodes first
+	addrs, _ := c.getNodeAddrs(false)
 	if len(addrs) == 0 {
-		addrs = c.StartupNodes
+		// when master nodes cannot be obtained, try to get all replicas
+		if addrs, _ = c.getNodeAddrs(true); len(addrs) == 0 {
+			// when there is no node information, StartupNodes is always used to populate
+			addrs = c.StartupNodes
+		}
 	}
 
 	for _, addr := range addrs {

--- a/cluster.go
+++ b/cluster.go
@@ -106,7 +106,13 @@ func (c *Cluster) refresh(bg bool) error {
 	var errMsgs []string
 	var oldm, newm [HashSlots][]string
 
-	addrs, _ := c.getNodeAddrs(false)
+	// get all node addrs, including replicas
+	addrs, _ := c.getNodeAddrs(true)
+	// when addrs cannot be obtained, StartupNodes is always used to populate
+	if len(addrs) == 0 {
+		addrs = c.StartupNodes
+	}
+
 	for _, addr := range addrs {
 		m, err := c.getClusterSlots(addr)
 		if err != nil {


### PR DESCRIPTION
When the cluster slots information has not yet been allocated, `getNodeAddrs` may return empty data, causing the masters and replicas information to be cleared and unable to be restored to the correct state.

In addition, we should regard the `getNodeAddrs` parameter `preferReplicas`, such as `EachNode`'s `replicas` or `getRandomConn`'s `readonly`, we cannot simply fill in the address of the replicas directly in `getNodeAddrs`.